### PR TITLE
Incorrect Admin URL

### DIFF
--- a/Oauth2Login.module
+++ b/Oauth2Login.module
@@ -69,7 +69,7 @@ class Oauth2Login extends WireData implements Module, ConfigurableModule {
         //$this->config->styles->add($this->config->urls->Oauth2Login . 'Oauth2Login.css');
         //$this->config->scripts->add($this->config->urls->Oauth2Login . 'Oauth2Login.js');
 
-        $this->backendUrl = $this->str_lreplace('//', '/', wire('config')->urls->httpRoot . wire('config')->urls->admin);
+        $this->backendUrl = urls()->httpAdmin;
 
         $this->processLogin();
     }


### PR DESCRIPTION
On PW Installations running in subdirectories (icf.church/ladieslounge) the redirect URL includes the subdirectory twice.